### PR TITLE
upgrade gifsicle to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "gifsicle": "^2.0.1",
+    "gifsicle": "^3.0.0",
     "memoizeasync": "^0.8.0",
     "which": "^1.0.9"
   },


### PR DESCRIPTION
The test suite passes even after the upgrade.

I have a project where I'm both using express-processimage and the webpack image-loader, which are incompatible versions of gifsicle (^2 and ^3). This brings them back in line - at least for now :-)
