### PR TITLE
Change in settting fallback binary path because require('gifsicle') d…

### DIFF
--- a/lib/Gifsicle.js
+++ b/lib/Gifsicle.js
@@ -17,7 +17,7 @@ inherits(Gifsicle, Stream);
 Gifsicle.findBinary = memoize(function(callback) {
   which('gifsicle', function(err, path) {
     if (err) {
-      path = require('gifsicle').path;
+      path = require('gifsicle');
     }
 
     if (path) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gifsicle-stream",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The gifsicle command line utility as a readable/writable stream.",
   "main": "lib/Gifsicle.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gifsicle-stream",
+  "name": "gifsicle-stream-paras20xx",
   "version": "0.3.1",
   "description": "The gifsicle command line utility as a readable/writable stream.",
   "main": "lib/Gifsicle.js",


### PR DESCRIPTION
…irectly exports path now (https://github.com/imagemin/gifsicle-bin/commit/47129c63be9678905c212ade61f3691e9a8a2c88)
